### PR TITLE
Minor api fixes on pixmap & PushButton

### DIFF
--- a/lib/PushButton.zig
+++ b/lib/PushButton.zig
@@ -23,7 +23,7 @@ pub fn init(opts: InitOptions) *PushButton {
     // Only free this data if we own it
     //defer if (opts.icon == null) c.QtC_Icon_delete(@constCast(icon));
 
-    return @ptrCast(c.QtC_PushButton_create(
+    return @ptrCast(c.QtC_PushButton_new(
         icon,
         str,
         @ptrCast(opts.parent),

--- a/lib/pixmap.cpp
+++ b/lib/pixmap.cpp
@@ -26,8 +26,9 @@ bool QtC_Pixmap_load(QtC_Pixmap* self, const QtC_String* filename, const char* f
 bool QtC_Pixmap_loadFromData(QtC_Pixmap* self, const char* data, int data_len, const char* format, int flags) {
     QPixmap* pixmap = reinterpret_cast<QPixmap*>(self);
 
-    return pixmap->load(
-        QString::fromUtf8(data, data_len),
+    return pixmap->loadFromData(
+        reinterpret_cast<const uchar *>(data),
+        data_len,
         format
     );
 }


### PR DESCRIPTION
I noticed the Zig binding for the PushButton widget was calling the wrong symbol. Additionally, the C binding for pixmap.loadFromData was calling the wrong C++ method.